### PR TITLE
Upgrade Redpanda image to v21.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.vectorized.io/vectorized/redpanda:v21.10.2
+FROM docker.vectorized.io/vectorized/redpanda:v21.11.1
 
 USER root
 


### PR DESCRIPTION
This PR updates the image to Redpanda v21.11.1, which brings the `rpk group` command:

```
Usage:
  rpk group [command]

Aliases:
  group, g

Available Commands:
  delete      Delete groups from brokers.
  describe    Describe group offset status & lag.
  list        List all groups.
  seek        Modify a group's current offsets.

Flags:
      --brokers strings         Comma-separated list of broker ip:port pairs (e.g. --brokers '192.168.78.34:9092,192.168.78.35:9092,192.179.23.54:9092' ). Alternatively, you may set the REDPANDA_BROKERS environment variable with the comma-separated list of broker addresses.
      --config string           Redpanda config file, if not set the file will be searched for in the default locations
  -h, --help                    help for group
      --password string         SASL password to be used for authentication.
      --sasl-mechanism string   The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
      --tls-cert string         The certificate to be used for TLS authentication with the broker.
      --tls-enabled             Enable TLS for the Kafka API (not necessary if specifying custom certs).
      --tls-key string          The certificate key to be used for TLS authentication with the broker.
      --tls-truststore string   The truststore to be used for TLS communication with the broker.
      --user string             SASL user to be used for authentication.

Global Flags:
  -v, --verbose   Enable verbose logging (default: false).

Use "rpk group [command] --help" for more information about a command.
```